### PR TITLE
feat: Decode unit field from datadogv2 protobuf

### DIFF
--- a/lib/protoparser/datadogv2/parser.go
+++ b/lib/protoparser/datadogv2/parser.go
@@ -118,13 +118,14 @@ type Series struct {
 
 	Type int `json:"type"`
 
-	Unit string
+	Unit string `json:"unit"`
 }
 
 func (s *Series) reset() {
 	s.Metric = ""
 	s.Interval = 0
 	s.Type = 0
+	s.Unit = ""
 
 	points := s.Points
 	for i := range points {
@@ -207,6 +208,12 @@ func (s *Series) unmarshalProtobuf(src []byte) (err error) {
 				return fmt.Errorf("cannot unmarshal type")
 			}
 			s.Type = int(typ)
+		case 6:
+			unit, ok := fc.String()
+			if !ok {
+				return fmt.Errorf("cannot unmarshal unit")
+			}
+			s.Unit = unit
 		case 8:
 			interval, ok := fc.Int64()
 			if !ok {


### PR DESCRIPTION
Closes D-7698

The agent sends unit as field 6 in MetricSeries protobuf but the parser never decoded it — Series.Unit was only populated from JSON bodies. Additionally, reset() didn't clear Unit, so pooled Series could bleed a stale unit into subsequent requests that lack one.
